### PR TITLE
Refactoring and prepend_before_filter

### DIFF
--- a/lib/browser-timezone-rails.rb
+++ b/lib/browser-timezone-rails.rb
@@ -6,17 +6,14 @@ require 'jstz-rails'
 module BrowserTimezoneRails
   module TimezoneControllerSetup
     def self.included(base)
-      base.send(:around_filter, :set_time_zone)
+      base.send(:prepend_around_filter, :set_time_zone)
     end
 
     private
 
-    def set_time_zone
-      old_time_zone = Time.zone
-      Time.zone = browser_timezone if browser_timezone.present?
-      yield
-    ensure
-      Time.zone = old_time_zone
+    def set_time_zone(&action)
+      # Use existing methods to simplify filter
+      Time.use_zone(browser_timezone.presence || Time.zone, &action)
     end
 
     def browser_timezone


### PR DESCRIPTION
I simplified the filter using existing rails core methods. Also I changed `before_filter` to `prepend_before_filter` because I had an issue in an activeadmin app where a record is loaded in some other filters so it doesn't work with this gem when I print record timestamp.

Generally speaking I think that this gem should prepend the filter (ideally it should be the first filter) otherwise you can have records with mixed timezones.