### PR TITLE
Changed the around_filter to use around_action

### DIFF
--- a/lib/browser-timezone-rails.rb
+++ b/lib/browser-timezone-rails.rb
@@ -6,7 +6,7 @@ require 'jstz-rails'
 module BrowserTimezoneRails
   module TimezoneControllerSetup
     def self.included(base)
-      base.send(:prepend_around_filter, :set_time_zone)
+      base.send(:prepend_around_action, :set_time_zone)
     end
 
     private


### PR DESCRIPTION
Updated to fix the deprecation notice thrown in Rails 5.0.0beta1

`DEPRECATION WARNING: around_filter is deprecated and will be removed in Rails 5.1. Use around_action instead.`

Fixes #22 