### PR TITLE
fix readme - it is referencing the gem name instead of the actual file to require

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ gem 'browser-timezone-rails'
 
 Make sure you have each of the following entries in your application.js:
 ```
-//= require js_cookie_rails
+//= require js.cookie
 //= require jstz
 //= require browser_timezone_rails/set_time_zone
 ```


### PR DESCRIPTION
require correct javascript file

fixes: https://github.com/kbaum/browser-timezone-rails/issues/29