### PR TITLE
Improvements

### DIFF
--- a/app/assets/javascripts/browser_timezone_rails/set_time_zone.js
+++ b/app/assets/javascripts/browser_timezone_rails/set_time_zone.js
@@ -16,7 +16,7 @@
   function setCookie() {
     var cookie = { timezone: getTimeZoneName() };
     var existingCookie = readCookie();
-    if !(existingCookie.override === undefined) {
+    if (existingCookie.override !== undefined) {
       return false;
     }
     if (existingCookie.timezone != cookie.timezone) {

--- a/app/assets/javascripts/browser_timezone_rails/set_time_zone.js
+++ b/app/assets/javascripts/browser_timezone_rails/set_time_zone.js
@@ -1,4 +1,42 @@
+"use strict";
+
 (function() {
-  Cookies.set("browser.timezone", jstz.determine().name(), { expires: 365, path: '/' });
+  var COOKIE_NAME = "browser.timezone";
+  var COOKIE_OPTS = { expires: 365, path: "/" };
+
+  function getTimeZoneName() {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    }
+    catch (_err) {
+      return jstz.determine().name();
+    }
+  }
+
+  function setCookie() {
+    var cookie = { timezone: getTimeZoneName() };
+    var existingCookie = readCookie();
+    if !(existingCookie.override === undefined) {
+      return false;
+    }
+    if (existingCookie.timezone != cookie.timezone) {
+      var event = new CustomEvent("setTimeZoneCookie", { detail: cookie });
+      Cookies.set(COOKIE_NAME, JSON.stringify(cookie), COOKIE_OPTS);
+      document.addEventListener("DOMContentLoaded", function() {
+        document.dispatchEvent(event);
+      }, false);
+    }
+  }
+
+  function readCookie() {
+    try {
+      return JSON.parse(Cookies.get(COOKIE_NAME));
+    }
+    catch (e) {
+      return({});
+    }
+  }
+
+  setCookie();
 })();
 

--- a/lib/browser-timezone-rails.rb
+++ b/lib/browser-timezone-rails.rb
@@ -16,7 +16,7 @@ module BrowserTimezoneRails
     end
 
     def browser_timezone
-      cookies["browser.timezone"]
+      JSON.parse(cookies["browser.timezone"])["timezone"]
     end
   end
 

--- a/lib/browser-timezone-rails.rb
+++ b/lib/browser-timezone-rails.rb
@@ -17,6 +17,8 @@ module BrowserTimezoneRails
 
     def browser_timezone
       JSON.parse(cookies["browser.timezone"])["timezone"]
+    rescue
+      nil
     end
   end
 


### PR DESCRIPTION
* use `Intl` if available, fallback to jstz. jstz is unreliable, for example it returns `Europe/Helsinki` instead of `Europe/Bucharest`, and `Intl` should be available in [all major browsers](http://caniuse.com/#feat=internationalization)
* store cookie data as JSON and allow user-override by setting
`override` in the cookie object
* trigger an event (`setTimeZoneCookie`) when a cookie is set and only
refresh the cookie if the timezone differs from the existing one. This event is triggered on `document`, after `DOMContentLoaded` and can be use like this (jquery is not required):

```javascript
    $(document).on('setTimeZoneCookie', function(e) {
      console.log('Time zone set to: ' + e.detail.timezone)
    })
```
