### PR TITLE
Do not load TimezoneControllerSetup to ActionController::API

### DIFF
--- a/lib/browser-timezone-rails.rb
+++ b/lib/browser-timezone-rails.rb
@@ -23,7 +23,9 @@ module BrowserTimezoneRails
   class Railtie < Rails::Engine
     initializer "browser_timezone_rails.controller" do
       ActiveSupport.on_load(:action_controller) do
-        include BrowserTimezoneRails::TimezoneControllerSetup
+        if self == ActionController::Base
+          include BrowserTimezoneRails::TimezoneControllerSetup
+        end
       end
     end
   end

--- a/spec/dummy/app/controllers/timezone_controller.rb
+++ b/spec/dummy/app/controllers/timezone_controller.rb
@@ -1,5 +1,5 @@
 class TimezoneController < ActionController::Base
   def show
-    render text: Time.zone
+    render plain: Time.zone
   end
 end

--- a/spec/dummy/config/initializers/secret_token.rb
+++ b/spec/dummy/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Dummy::Application.config.secret_token = 'cc6e88d5b41784239495a56a355e67fc2dfedccb7b5430a2ee9bd7438abd8fb64eab7e7ac6bb0b25d89a9da529864ad4df5c6a40e94b78a3e10e4dcd81768688'
+Dummy::Application.config.secret_key_base = 'cc6e88d5b41784239495a56a355e67fc2dfedccb7b5430a2ee9bd7438abd8fb64eab7e7ac6bb0b25d89a9da529864ad4df5c6a40e94b78a3e10e4dcd81768688'

--- a/spec/request/set_timezone_spec.rb
+++ b/spec/request/set_timezone_spec.rb
@@ -18,11 +18,11 @@ describe 'sets the timezone', type: :request do
     end
 
     it 'sets the timezone properly' do
-      page.should have_content "Australia/Sydney"
+      expect(page).to have_content "Australia/Sydney"
     end
 
     it 'resets the time zone back to utc after each request' do
-      Time.zone.name.should == 'UTC'
+      expect(Time.zone.name).to eq('UTC')
     end
   end
 
@@ -33,7 +33,7 @@ describe 'sets the timezone', type: :request do
     end
 
     it 'does not raise an error' do
-      page.should have_content "UTC"
+      expect(page).to have_content "UTC"
     end
   end
 
@@ -45,7 +45,7 @@ describe 'sets the timezone', type: :request do
     end
 
     it 'sets the timezone properly' do
-      page.should have_content "(GMT+00:00) UTC"
+      expect(page).to have_content "(GMT+00:00) UTC"
     end
 
   end


### PR DESCRIPTION
Currently, this gem tries to include helper methods to every type of ActionController including ActionController::API. ActionController::API does not have cookies so we're getting an error
```
NameError: undefined local variable or method `cookies'
```

This will include helpers only to `ActionController::Base`