### PR TITLE
When using force_ssl in the application, mark the cookie as secure

### DIFF
--- a/app/assets/javascripts/browser_timezone_rails/set_time_zone.js
+++ b/app/assets/javascripts/browser_timezone_rails/set_time_zone.js
@@ -1,4 +1,0 @@
-(function() {
-  Cookies.set("browser.timezone", jstz.determine().name(), { expires: 365, path: '/' });
-})();
-

--- a/app/assets/javascripts/browser_timezone_rails/set_time_zone.js.erb
+++ b/app/assets/javascripts/browser_timezone_rails/set_time_zone.js.erb
@@ -1,0 +1,13 @@
+(function() {
+
+  Cookies.set(
+    "browser.timezone",
+    jstz.determine().name(),
+    {
+      expires: 365,
+      path: '/',
+      secure: <%= ::Rails.application.config.force_ssl %>
+    }
+  );
+})();
+


### PR DESCRIPTION
This avoids false positives from security audits. There's no actual security benefit.

Resolves #40 