### PR TITLE
Use modern ECMAScript Internationalization API for setting cookie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 env:
   - "RAILS_VERSION=3.2.22.5"
+  - "RAILS_VERSION=4.0.13"
+  - "RAILS_VERSION=4.1.16"
   - "RAILS_VERSION=4.2.11"
   - "RAILS_VERSION=5.2.3"
   - "RAILS_VERSION=master"

--- a/README.md
+++ b/README.md
@@ -16,14 +16,19 @@ gem 'browser-timezone-rails'
 Make sure you have each of the following entries in your application.js:
 ```
 //= require js.cookie
-//= require jstz
 //= require browser_timezone_rails/set_time_zone
 ```
 That's it! No other configuration is needed as it's all done for you with this gem including setting up your application controller to start using your users' zones.
 
 ## How it works
 
-The browsers timezone is set in a cookie using the awesome [jsTimezoneDetect](https://bitbucket.org/pellepim/jstimezonedetect) javascript library.  That cookie is then read during each request to set the Rails timezone for that user.
+The browser's timezone is set in a cookie using the modern [ECMAScript Internationalization API](https://www.ecma-international.org/ecma-402/)
+
+Caveat: doesn't work with Internet Explorer.
+
+(Up to 1.0.4 version of the gem, the cookie was set via the [jsTimezoneDetect](https://bitbucket.org/pellepim/jstimezonedetect) javascript library, which, however, was often inaccurate.)  
+
+That cookie is then read during each request to set the Rails timezone for that user.
 
 You can also read more about this implementation here: [Blog](http://cowjumpedoverthecommodore64.blogspot.in/2013/03/setting-rails-timezone-to-users.html)
 

--- a/app/assets/javascripts/browser_timezone_rails/set_time_zone.js.erb
+++ b/app/assets/javascripts/browser_timezone_rails/set_time_zone.js.erb
@@ -2,7 +2,7 @@
 
   Cookies.set(
     "browser.timezone",
-    jstz.determine().name(),
+    Intl.DateTimeFormat().resolvedOptions().timeZone,
     {
       expires: 365,
       path: '/',
@@ -10,4 +10,3 @@
     }
   );
 })();
-

--- a/browser-timezone-rails.gemspec
+++ b/browser-timezone-rails.gemspec
@@ -6,7 +6,7 @@ require "browser-timezone-rails/version"
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "browser-timezone-rails"
-  s.version     = '1.0.4'
+  s.version     = '1.1.0'
   s.version     = BrowserTimezoneRails::VERSION
   s.authors     = ["kbaum"]
   s.email       = ["karl.baum@gmail.com"]
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 3.1"
   s.add_dependency "js_cookie_rails"
-  s.add_dependency "jstz-rails3-plus"
 
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "capybara"

--- a/lib/browser-timezone-rails.rb
+++ b/lib/browser-timezone-rails.rb
@@ -2,10 +2,9 @@
 
 require 'browser-timezone-rails/engine'
 require 'js_cookie_rails'
-require 'jstz-rails'
 
 module BrowserTimezoneRails
-  PREPEND_METHOD = if Rails::VERSION::MAJOR == 3 || (Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR >= 2)
+  PREPEND_METHOD = if Rails::VERSION::MAJOR == 3 || (Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR < 2)
                      :prepend_around_filter
                    else
                      :prepend_around_action

--- a/lib/browser-timezone-rails/version.rb
+++ b/lib/browser-timezone-rails/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BrowserTimezoneRails
-  VERSION = "1.0.4"
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
Replaced the jstimezonedetect library, which was often inaccurate (for example, detecting my timezone as Europe/Helsinki instead of Europe/Chisinau) - see this [StackOverflow answer](https://stackoverflow.com/a/22625076/4812102), with the modern ECMAScript Internationalization API call.

Fixed the gem to work correctly with Rails 4.0.x and 4.1.x (added these Rails versions to Travis matrix to ensure testing).

